### PR TITLE
Add support for operator == on wrappers

### DIFF
--- a/Haxe/Static/ue4hx/internal/NeedsGlueBuild.hx
+++ b/Haxe/Static/ue4hx/internal/NeedsGlueBuild.hx
@@ -375,7 +375,7 @@ $prelude
             return false;
 
           ${noParams.getCppClass()} obj = inRHS;
-          if (!obj.mPtr) return false;
+          if (!obj.mPtr) return true;
           return mPtr->wrapped$getPointer != obj.mPtr->wrapped$getPointer;
         }
         $startNamespaces

--- a/Haxe/Static/unreal/CoreAPI.hx
+++ b/Haxe/Static/unreal/CoreAPI.hx
@@ -7,23 +7,6 @@ import unreal.Wrapper;
 @:access(unreal.UObject.wrapped)
 class CoreAPI {
 
-  public static function pointerEquals(a:Dynamic, b:Dynamic) : Bool {
-    if ((a == null) && (b == null)) {
-      return true;
-    } else if (a == null || b == null) {
-      return false;
-    } else if (Std.is(a, Wrapper) && Std.is(b, Wrapper)) {
-      var wrapperA:Wrapper = cast a;
-      var wrapperB:Wrapper = cast b;
-      return wrapperA.wrapped.ptr.getPointer() == wrapperB.wrapped.ptr.getPointer();
-    } else if (Std.is(a, unreal.UObject) && Std.is(b, UObject)) {
-      var uobjectA:UObject = cast a;
-      var ubojectB:UObject = cast b;
-      return uobjectA.wrapped == ubojectB.wrapped;
-    }
-    return a == b;
-  }
-
   public static function equals(a:Dynamic, b:Dynamic) : Bool {
     if ((a == null) && (b == null)) {
       return true;


### PR DESCRIPTION
This adds a specialization of `hx::ObjectPtr` for each type that extends `UObject` or `Wrapper`. It also overrides `__Compare` on `UObject` and `Wrapper`. Tests say it's okay
- [x] @dogles 
