### PR TITLE
Fix hot reloading issue with calling functions in the default object

### DIFF
--- a/Haxe/Static/ue4hx/internal/UExtensionBuild.hx
+++ b/Haxe/Static/ue4hx/internal/UExtensionBuild.hx
@@ -571,6 +571,9 @@ class UExtensionBuild {
     } else {
       headerDef.add('\t\t${ueName}(const FObjectInitializer& ObjectInitializer = FObjectInitializer::Get()) : $superName($objectInit) {$ctorBody}\n');
     }
+    if (!hasHaxeSuper) {
+      headerDef.add('\t\tvoid Serialize( FArchive& Ar ) override {\n\t\t\tSuper::Serialize(Ar);\n\t\t\tif (!Ar.IsSaving() && this->haxeGcRef.get() == nullptr) this->haxeGcRef.set(this->createHaxeWrapper());\n\t\t}\n');
+    }
 
     metas.push({ name: ':glueHeaderIncludes', params:[for (inc in includes) macro $v{inc}], pos: clt.pos });
     metas.push({ name: ':ueHeaderDef', params:[macro $v{headerDef.toString()}], pos: clt.pos });


### PR DESCRIPTION
It's still not very clear if this is the best fix for it. For now, all we know is that
some overridden UObject functions crash in Haxe when hot reloading. This is not affected by
normal serialization/unserialization (even though the fix is on the `Serialize` function).
It seems to have to do with how some hot reloaded objects are created and skip somehow the constructor.
By running through a debugger, this fix is actually called by `FHotReloadModule::ReplaceReferencesToReconstructedCDOs()`,
which in its turn calls `FFindReferencesArchive`, which calls `Serialize` without either `IsLoading()` or `IsSaving()` flag
set - so it can find references to the old CDOs. We might come up with a better fix later then, since
this doesn't seem like it's the 100% appropriate place for the fix to be.

* [ ] @dogles 