### PR TITLE
Add http protocol to Haxe's FQDN

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Unreal.hx
 
-Unreal.hx is a plugin for Unreal Engine 4 that allows you to write code in the [Haxe](haxe.org) programming language. Haxe is a modern, high-level, type-safe programming language that offers high performance critical for game development.
+Unreal.hx is a plugin for Unreal Engine 4 that allows you to write code in the [Haxe](http://haxe.org/) programming language. Haxe is a modern, high-level, type-safe programming language that offers high performance critical for game development.
 
 ### Main Features
 - Haxe compiles directly to C++, for high runtime performance.


### PR DESCRIPTION
The link to the Haxe website doesn't currently work when rendered on GitHub because it's missing `http://`. Fix attached for your consideration :metal::neckbeard:

Cheers,
  Lee :beers: