### PR TITLE
Fix occasional `isValid` false positive

### DIFF
--- a/Haxe/Static/ue4hx/internal/ExternBaker.hx
+++ b/Haxe/Static/ue4hx/internal/ExternBaker.hx
@@ -683,14 +683,14 @@ class ExternBaker {
           this.add('inline public function isValid(threadSafe:Bool=false):Bool');
           this.begin(' {');
             // make an inline version that checks if `this` is null as well
-            this.add('return this != null && this.wrapped != 0 && this.pvtIsValid(threadSafe);');
+            this.add('return this != null && this.pvtIsValid(threadSafe);');
           this.end('}');
 
           this.add('#if (!cppia && !debug) inline #end private function pvtIsValid(threadSafe:Bool):Bool');
           this.begin(' {');
-            this.add('return this.wrapped != 0 '
-                +' && unreal.helpers.ObjectArrayHelper_Glue.objectToIndex(this.wrapped) == internalIndex '
-                +' && (!threadSafe || unreal.helpers.ObjectArrayHelper_Glue.isValid(internalIndex, serialNumber, false));');
+            this.add('return this.wrapped != 0 && '
+                +' unreal.helpers.ObjectArrayHelper_Glue.objectToIndex(this.wrapped) == internalIndex && '
+                +' (!threadSafe || unreal.helpers.ObjectArrayHelper_Glue.isValid(internalIndex, serialNumber, false));');
           this.end('}');
         }
 

--- a/Haxe/Static/unreal/helpers/ClassWrap.hx
+++ b/Haxe/Static/unreal/helpers/ClassWrap.hx
@@ -61,7 +61,7 @@ import unreal.*;
       var index = inds[i],
           obj = wrapperArray[index];
       var ptr = ObjectArrayHelper_Glue.indexToObject(index);
-      if (obj != null && ptr == obj.wrapped && ObjectArrayHelper_Glue.indexToSerial(index) == obj.serialNumber) {
+      if (obj != null && ptr == obj.wrapped && ObjectArrayHelper_Glue.indexToSerialPendingKill(index) == obj.serialNumber) {
         inds[nidx++] = index;
       } else {
         if (obj != null) {

--- a/Haxe/Static/unreal/helpers/ObjectArrayHelper.hx
+++ b/Haxe/Static/unreal/helpers/ObjectArrayHelper.hx
@@ -23,6 +23,14 @@ class ObjectArrayHelper implements ue4hx.internal.NeedsGlue {
     return ObjectArrayHelper_Glue.indexToSerial(idx);
   }
 
+  @:glueHeaderCode('static int indexToSerialPendingKill(int index);')
+  @:glueCppCode('int unreal::helpers::ObjectArrayHelper_Glue_obj::indexToSerialPendingKill(int index) {\n\tauto ret = GUObjectArray.IndexToObject(index);\n\tif (ret == nullptr || ret->IsPendingKill() || ret->IsUnreachable()) return 0;\n\treturn ret->SerialNumber;\n}')
+  @:glueCppIncludes('UObject/UObjectArray.h')
+  @:glueHeaderIncludes('IntPtr.h')
+  public static function indexToSerialPendingKill(idx:Int):Int {
+    return ObjectArrayHelper_Glue.indexToSerialPendingKill(idx);
+  }
+
   @:glueHeaderCode('static int objectToIndex(unreal::UIntPtr obj);')
   @:glueCppCode('int unreal::helpers::ObjectArrayHelper_Glue_obj::objectToIndex(unreal::UIntPtr obj) {\n\treturn GUObjectArray.ObjectToIndex((const class UObjectBase *) obj);\n}')
   @:glueCppIncludes('UObject/UObjectArray.h')

--- a/Haxe/Static/unreal/helpers/ObjectArrayHelper_Glue.hx
+++ b/Haxe/Static/unreal/helpers/ObjectArrayHelper_Glue.hx
@@ -3,6 +3,7 @@ package unreal.helpers;
 @:unrealGlue extern class ObjectArrayHelper_Glue {
   public static function indexToObject(idx:Int):unreal.UIntPtr;
   public static function indexToSerial(idx:Int):Int;
+  public static function indexToSerialPendingKill(idx:Int):Int;
   public static function objectToIndex(obj:unreal.UIntPtr):Int;
   public static function allocateSerialNumber(idx:Int):Int;
   public static function isValid(index:Int, serial:Int, evenIfPendingKill:Bool):Bool;


### PR DESCRIPTION
This happens because we used to check whether an object was valid simply
by checking the existence of its position on the object array;
However, on some cases, an object is marked as pending kill and not taken
off from the object array immediately.
This led to objects being deleted after garbage collection was done,
at which case it was too late to invalidate them on the Haxe side.
That's why there is a `IsPendingKill` check.

The fix is simple: Add a pending kill and unreachable check
so that we invalidate these cases as well.

References:
Main garbage collection loop where objects are set as pending kill - https://github.com/EpicGames/UnrealEngine/blob/4.11/Engine/Source/Runtime/CoreUObject/Private/UObject/GarbageCollection.cpp#L1301
PostGarbageCollect hook call, where we invalidate the objects on the haxe-side - https://github.com/EpicGames/UnrealEngine/blob/4.11/Engine/Source/Runtime/CoreUObject/Private/UObject/GarbageCollection.cpp#L1322 (called synchronously)

IsPendingKill / IsUnreachable calls - https://github.com/EpicGames/UnrealEngine/blob/release/Engine/Source/Runtime/CoreUObject/Public/UObject/UObjectArray.h#L127 (just a flag check, shouldn't slow down the invalidation checks)