### PR TITLE
IPlatformFile uses POwnedPtr<IFileHandle>

### DIFF
--- a/Haxe/Externs/unreal/IPlatformFile.hx
+++ b/Haxe/Externs/unreal/IPlatformFile.hx
@@ -8,6 +8,7 @@ package unreal;
   function FileSize(file:TCharStar):Int64;
   function GetName():TCharStar;
   static function GetPlatformPhysical():PRef<IPlatformFile>;
-  function OpenRead(filename:TCharStar, allowWrite:Bool):PPtr<IFileHandle>;
-  function OpenWrite(filename:TCharStar, append:Bool, allowRead:Bool):PPtr<IFileHandle>;
+  // You must call .dispose() on these file handles to close the files
+  function OpenRead(filename:TCharStar, allowWrite:Bool):POwnedPtr<IFileHandle>;
+  function OpenWrite(filename:TCharStar, append:Bool, allowRead:Bool):POwnedPtr<IFileHandle>;
 }


### PR DESCRIPTION
- IPlatformFile.OpenRead() and OpenWrite() return POwnedPtr<IFileHandle> now.
Functions using these need to convert to TSharedPtr<IFileHandle> and dispose()
of the result to close the file.