### PR TITLE
Use the most significant bit instead of the least as a tag

### DIFF
--- a/Haxe/Static/uhx/compiletime/UExtensionBuild.hx
+++ b/Haxe/Static/uhx/compiletime/UExtensionBuild.hx
@@ -517,7 +517,7 @@ class UExtensionBuild {
             cppCode += '\tSuper::PreReplication(ChangedPropertyTracker);\n';
             cppCode += '\tuhx::expose::HxcppRuntime::instancePreReplication(' +
                 '(unreal::UIntPtr) this, ' +
-                'unreal::VariantPtr(&ChangedPropertyTracker));\n';
+                'unreal::VariantPtr::fromExternalPointer(&ChangedPropertyTracker));\n';
             cppCode += '}\n\n';
           }
         } else if (hasReplicatedProperties) {
@@ -639,7 +639,8 @@ class UExtensionBuild {
         case FFun(fn):
           var fnRet = fn.ret;
           var isVoid = fnRet.match(TPath({ name:'Void' }));
-          var nullExpr = macro untyped __cpp__('0');
+          // var nullExpr = macro untyped __cpp__('0');
+          var nullExpr = macro cast null;
           var nameVal = typeRef.name + '.' + field.name;
           var oldExpr = fn.expr;
           if (hasReturn(oldExpr)) {
@@ -851,7 +852,7 @@ class UExtensionBuild {
     headerDef << new End('}') << new Newline();
     if (!hasHaxeSuper) {
       includes.add('uhx/ThreadAttach.h');
-      headerDef << 'void Serialize( FArchive& Ar ) override' << new Begin(' {') 
+      headerDef << 'void Serialize( FArchive& Ar ) override' << new Begin(' {')
         << 'Super::Serialize(Ar);' << new Newline()
         << 'uhx::ThreadAttach threadAttach(true);' << new Newline()
         << 'if (!Ar.IsSaving() && this->haxeGcRef.get() == 0) this->haxeGcRef.set(this->createEmptyHaxeWrapper());'
@@ -861,8 +862,8 @@ class UExtensionBuild {
     if (Globals.isDynamicUType(clt) && (clt.superClass == null || !Globals.isDynamicUType(clt.superClass.t.get()))) {
       includes.add('UObject/Stack.h');
       headerDef << 'public:' << new Newline()
-        << 'static void ${Globals.UHX_CALL_FUNCTION}( UObject* Context, FFrame& Stack, RESULT_DECL ) ' << new Begin(" {") 
-          << '::uhx::expose::HxcppRuntime::callHaxeFunction(reinterpret_cast<unreal::UIntPtr>(Context), unreal::VariantPtr(&Stack), reinterpret_cast<unreal::UIntPtr>(RESULT_PARAM));'
+        << 'static void ${Globals.UHX_CALL_FUNCTION}( UObject* Context, FFrame& Stack, RESULT_DECL ) ' << new Begin(" {")
+          << '::uhx::expose::HxcppRuntime::callHaxeFunction(reinterpret_cast<unreal::UIntPtr>(Context), unreal::VariantPtr::fromExternalPointer(&Stack), reinterpret_cast<unreal::UIntPtr>(RESULT_PARAM));'
         << new End('}') << new Newline();
     }
 

--- a/Haxe/Static/uhx/compiletime/UExtensionBuild.hx
+++ b/Haxe/Static/uhx/compiletime/UExtensionBuild.hx
@@ -639,7 +639,6 @@ class UExtensionBuild {
         case FFun(fn):
           var fnRet = fn.ret;
           var isVoid = fnRet.match(TPath({ name:'Void' }));
-          // var nullExpr = macro untyped __cpp__('0');
           var nullExpr = macro cast null;
           var nameVal = typeRef.name + '.' + field.name;
           var oldExpr = fn.expr;

--- a/Haxe/Static/uhx/compiletime/main/ExternBaker.hx
+++ b/Haxe/Static/uhx/compiletime/main/ExternBaker.hx
@@ -1069,7 +1069,7 @@ class ExternBaker {
               this.newline();
               this.add('if (!ops.HasZeroConstructor()) ops.Construct(( ( cast ret : unreal.VariantPtr).getDynamic() : unreal.Wrapper).getPointer());');
               this.newline();
-              this.add('ops.Copy(( ( cast ret : unreal.VariantPtr).getDynamic() : unreal.Wrapper).getPointer(), (cast this : unreal.VariantPtr).getUnderlyingPointer(), 1);');
+              this.add('ops.Copy(( ( cast ret : unreal.VariantPtr).getDynamic() : unreal.Wrapper).getPointer(), uhx.internal.HaxeHelpers.getUnderlyingPointer(cast this), 1);');
               this.newline();
               this.add('return ret;');
           this.end('}');

--- a/Haxe/Static/uhx/compiletime/main/ExternBaker.hx
+++ b/Haxe/Static/uhx/compiletime/main/ExternBaker.hx
@@ -1069,7 +1069,7 @@ class ExternBaker {
               this.newline();
               this.add('if (!ops.HasZeroConstructor()) ops.Construct(( ( cast ret : unreal.VariantPtr).getDynamic() : unreal.Wrapper).getPointer());');
               this.newline();
-              this.add('ops.Copy(( ( cast ret : unreal.VariantPtr).getDynamic() : unreal.Wrapper).getPointer(), uhx.internal.Helpers.getWrapperPointer(cast this), 1);');
+              this.add('ops.Copy(( ( cast ret : unreal.VariantPtr).getDynamic() : unreal.Wrapper).getPointer(), (cast this : unreal.VariantPtr).getUnderlyingPointer(), 1);');
               this.newline();
               this.add('return ret;');
           this.end('}');

--- a/Haxe/Static/uhx/compiletime/main/NativeGlueCode.hx
+++ b/Haxe/Static/uhx/compiletime/main/NativeGlueCode.hx
@@ -22,13 +22,16 @@ class NativeGlueCode
   private var producedFiles:Array<String>;
 
   private var stampOutput:String;
+  // This version gets bumped each time a fundamental glue generation has changed
+  // so that all previous genereated files should be considered outdated
+  private static var glueGenerationVersion = 1;
 
   public function new() {
     this.glues = new GlueManager(this);
     this.producedFiles = [];
     this.modules = new Map();
     this.glueTypes = new Map();
-    this.stampOutput = haxe.macro.Compiler.getOutput() + '/Stamps';
+    this.stampOutput = haxe.macro.Compiler.getOutput() + '/Stamps/$glueGenerationVersion';
     if (!FileSystem.exists(this.stampOutput)) {
       FileSystem.createDirectory(this.stampOutput);
     }

--- a/Haxe/Static/uhx/compiletime/types/GlueMethod.hx
+++ b/Haxe/Static/uhx/compiletime/types/GlueMethod.hx
@@ -523,8 +523,8 @@ class GlueMethod {
       }
     } else if (meth.uname == '.equals') {
       // these variables are guaranteed to have this name - see getCppBody
-      outVars << 'if (self.raw == other.raw) { return true; }';
-      outVars << 'if (self.raw == 0 || other.raw == 0) { return false; }';
+      outVars << 'if (self == other) { return true; }';
+      outVars << 'if (self.isNull() || other.isNull()) { return false; }';
       body += '(' + cppArgTypes.join(', ') + ')';
     } else {
       body += '(' + cppArgTypes.join(', ') + ')';

--- a/Haxe/Static/uhx/compiletime/types/TypeConv.hx
+++ b/Haxe/Static/uhx/compiletime/types/TypeConv.hx
@@ -744,7 +744,7 @@ class TypeConv {
       case CMethodPointer(cname, args, ret):
         expr;
       case CTypeParam(name, _):
-        'uhx.internal.HaxeHelpers.variantToPointer( $expr )';
+        '( cast $expr : unreal.VariantPtr ).getUIntPtrRepresentation()';
     }
   }
 
@@ -960,9 +960,9 @@ class TypeConv {
           }
         } else {
           if (hasModifier(Ref)) {
-            'unreal::VariantPtr( (void *) &($expr) )';
+            'unreal::VariantPtr::fromExternalPointer( (void *) &($expr) )';
           } else if (hasModifier(Ptr)) {
-            'unreal::VariantPtr( (void *) ($expr) )';
+            'unreal::VariantPtr::fromExternalPointer( (void *) ($expr) )';
           } else {
             '::uhx::StructHelper<${this.ueType.withoutPointer(true).withConst(false).getCppType()}>::fromStruct($expr)';
           }

--- a/Haxe/Static/uhx/expose/BaseRuntime.hx
+++ b/Haxe/Static/uhx/expose/BaseRuntime.hx
@@ -1,0 +1,35 @@
+package uhx.expose;
+import unreal.UIntPtr;
+
+/**
+  This is just like `HxcppRuntime`, but provides a minimal API for the VariantPtr implementation
+**/
+@:uexpose @:keep class BaseRuntime
+{
+  @:void public static function throwString(str:cpp.ConstCharStar) : Void {
+    throw str.toString();
+  }
+
+  public static function wrapperObjectToPointer(wrapperPtr:UIntPtr):UIntPtr {
+    var wrapper:unreal.Wrapper = uhx.internal.HaxeHelpers.pointerToDynamic(wrapperPtr);
+    return wrapper.getPointer();
+  }
+
+  @:void public static function throwBadPointer(ptr:UIntPtr) : Void {
+    throw 'The pointer "$ptr" is invalid';
+  }
+
+  public static function boxPointer(ptr:UIntPtr):UIntPtr
+  {
+    var vptr = unreal.VariantPtr.fromExternalPointer(ptr);
+    var ret:Dynamic = vptr;
+    return uhx.internal.HaxeHelpers.dynamicToPointer(ret);
+  }
+
+  public static function getPointerHandle(ptr:UIntPtr):UIntPtr
+  {
+    var dyn:Dynamic = uhx.internal.HaxeHelpers.pointerToDynamic(ptr);
+    var ptr:UIntPtr = untyped __cpp__("(unreal::UIntPtr) ({0}->__GetHandle())", dyn);
+    return ptr;
+  }
+}

--- a/Haxe/Static/uhx/expose/HxcppRuntime.hx
+++ b/Haxe/Static/uhx/expose/HxcppRuntime.hx
@@ -134,7 +134,7 @@ import uhx.internal.Helpers;
     var ret = VariantPtr.fromDynamic( InlinePodWrapper.create(size, info) );
 #if debug
     if (ret.isExternalPointer()) {
-      throw 'Assertion failed: Hxcpp allocated unaligned structure';
+      throw 'Assertion failed: Hxcpp allocated invalid pointer $ret';
     }
 #end
     return ret;
@@ -144,7 +144,7 @@ import uhx.internal.Helpers;
     var ret = VariantPtr.fromDynamic( InlineWrapper.create(size, info) );
 #if debug
     if (ret.isExternalPointer()) {
-      throw 'Assertion failed: Hxcpp allocated unaligned structure';
+      throw 'Assertion failed: Hxcpp allocated invalid pointer $ret';
     }
 #end
     return ret;
@@ -154,7 +154,7 @@ import uhx.internal.Helpers;
     var ret = VariantPtr.fromDynamic( AlignedInlineWrapper.create(size, info) );
 #if debug
     if (ret.isExternalPointer()) {
-      throw 'Assertion failed: Hxcpp allocated unaligned structure';
+      throw 'Assertion failed: Hxcpp allocated invalid pointer $ret';
     }
 #end
     return ret;
@@ -164,7 +164,7 @@ import uhx.internal.Helpers;
     var ret = VariantPtr.fromDynamic( InlineTemplateWrapper.create(size, info) );
 #if debug
     if (ret.isExternalPointer()) {
-      throw 'Assertion failed: Hxcpp allocated unaligned structure';
+      throw 'Assertion failed: Hxcpp allocated invalid pointer $ret';
     }
 #end
     return ret;
@@ -174,7 +174,7 @@ import uhx.internal.Helpers;
     var ret = VariantPtr.fromDynamic( PointerTemplateWrapper.create(pointer, info, extraSize) );
 #if debug
     if (ret.isExternalPointer()) {
-      throw 'Assertion failed: Hxcpp allocated unaligned structure';
+      throw 'Assertion failed: Hxcpp allocated invalid pointer $ret';
     }
 #end
     return ret;

--- a/Haxe/Static/uhx/expose/HxcppRuntime.hx
+++ b/Haxe/Static/uhx/expose/HxcppRuntime.hx
@@ -133,7 +133,7 @@ import uhx.internal.Helpers;
   public static function createInlinePodWrapper(size:Int, info:UIntPtr) : VariantPtr {
     var ret = VariantPtr.fromDynamic( InlinePodWrapper.create(size, info) );
 #if debug
-    if (ret.raw & 1 == 1) {
+    if (ret.isExternalPointer()) {
       throw 'Assertion failed: Hxcpp allocated unaligned structure';
     }
 #end
@@ -143,7 +143,7 @@ import uhx.internal.Helpers;
   public static function createInlineWrapper(size:Int, info:UIntPtr) : VariantPtr {
     var ret = VariantPtr.fromDynamic( InlineWrapper.create(size, info) );
 #if debug
-    if (ret.raw & 1 == 1) {
+    if (ret.isExternalPointer()) {
       throw 'Assertion failed: Hxcpp allocated unaligned structure';
     }
 #end
@@ -153,7 +153,7 @@ import uhx.internal.Helpers;
   public static function createAlignedInlineWrapper(size:Int, info:UIntPtr) : VariantPtr {
     var ret = VariantPtr.fromDynamic( AlignedInlineWrapper.create(size, info) );
 #if debug
-    if (ret.raw & 1 == 1) {
+    if (ret.isExternalPointer()) {
       throw 'Assertion failed: Hxcpp allocated unaligned structure';
     }
 #end
@@ -163,7 +163,7 @@ import uhx.internal.Helpers;
   public static function createInlineTemplateWrapper(size:Int, info:UIntPtr) : VariantPtr {
     var ret = VariantPtr.fromDynamic( InlineTemplateWrapper.create(size, info) );
 #if debug
-    if (ret.raw & 1 == 1) {
+    if (ret.isExternalPointer()) {
       throw 'Assertion failed: Hxcpp allocated unaligned structure';
     }
 #end
@@ -173,7 +173,7 @@ import uhx.internal.Helpers;
   public static function createPointerTemplateWrapper(pointer:UIntPtr, info:UIntPtr, extraSize:Int) : VariantPtr {
     var ret = VariantPtr.fromDynamic( PointerTemplateWrapper.create(pointer, info, extraSize) );
 #if debug
-    if (ret.raw & 1 == 1) {
+    if (ret.isExternalPointer()) {
       throw 'Assertion failed: Hxcpp allocated unaligned structure';
     }
 #end
@@ -203,10 +203,6 @@ import uhx.internal.Helpers;
 
   public static function getInlinePodWrapperOffset() : UIntPtr {
     return unreal.Wrapper.InlinePodWrapper.getOffset();
-  }
-
-  public static function getWrapperPointer(vptr : VariantPtr) : UIntPtr {
-    return Helpers.getWrapperPointer(vptr);
   }
 
   public static function setWrapperStructInfo(wrapper : UIntPtr, info : UIntPtr) : Void {

--- a/Haxe/Static/uhx/internal/HaxeHelpers.hx
+++ b/Haxe/Static/uhx/internal/HaxeHelpers.hx
@@ -17,12 +17,12 @@ class HaxeHelpers
     return dyn;
   }
 
-  /**
-    Same as `dynamicToPointer`, but is aware of variant pointers, and if `dyn` is a raw pointer, will return the unboxed pointer value instead
-   **/
-  @:ifFeature("uhx.internal.HaxeHelpers.*") public static function variantToPointer(dyn:Dynamic):unreal.UIntPtr {
-    var variant:VariantPtr = dyn;
-    return untyped __cpp__('(unreal::UIntPtr) {0}.raw',variant);
+  #if !cppia
+  inline
+  #end
+  public static function getUnderlyingPointer(vptr:VariantPtr)
+  {
+    return vptr.getUnderlyingPointer();
   }
 
   @:extern inline public static function getUObjectWrapped(uobj:UObject):UIntPtr {

--- a/Haxe/Static/uhx/internal/Helpers.hx
+++ b/Haxe/Static/uhx/internal/Helpers.hx
@@ -4,15 +4,6 @@ import unreal.*;
 class Helpers {
   public static var pointerSize(default, null):Int = untyped __cpp__("(int) (sizeof (void *))");
 
-  public static function getWrapperPointer(vptr : VariantPtr) : UIntPtr {
-    if (vptr.isObject()) {
-      var wrapper:Wrapper = vptr.getDynamic();
-      return wrapper.getPointer();
-    } else {
-      return vptr.getUIntPtr() - 1;
-    }
-  }
-
   public static function createPodWrapper(size:Int) {
     return unreal.Wrapper.InlinePodWrapper.create(size, 0);
   }

--- a/Haxe/Static/unreal/AnyPtr.hx
+++ b/Haxe/Static/unreal/AnyPtr.hx
@@ -151,7 +151,7 @@ abstract AnyPtr(UIntPtr) from UIntPtr to UIntPtr {
   }
 
   public function getStruct(at:Int):Struct {
-    return cast VariantPtr.fromUIntPtr(this + at + 1);
+    return cast VariantPtr.fromExternalPointer(this + at);
   }
 
   public static function fromUObject(obj:UObject):AnyPtr {
@@ -160,11 +160,7 @@ abstract AnyPtr(UIntPtr) from UIntPtr to UIntPtr {
 
   public static function fromStruct(obj:Struct):AnyPtr {
     var variantPtr:VariantPtr = cast obj;
-    if (variantPtr.isObject()) {
-      return (variantPtr.getDynamic() : Wrapper).getPointer();
-    } else {
-      return variantPtr.raw - 1;
-    }
+    return variantPtr.getUnderlyingPointer();
   }
 
   public static function fromNull():AnyPtr {

--- a/Haxe/Static/unreal/Ptr.hx
+++ b/Haxe/Static/unreal/Ptr.hx
@@ -8,7 +8,7 @@ package unreal;
 abstract Ptr<T>(PtrMacros<T>) {
   /**
     Creates a reference of the target type in the stack. The reference is only guaranteed to be
-    alive 
+    alive
   **/
   macro public static function createStack<T>():haxe.macro.Expr.ExprOf<Ref<T>> {
     return PtrMacros.createStackHelper(false);
@@ -21,7 +21,8 @@ abstract Ptr<T>(PtrMacros<T>) {
   }
 
   public static function fromStruct<T : Struct>(struct : Struct):Ptr<T> {
-    return cast uhx.internal.Helpers.getWrapperPointer(struct);
+    var vptr:VariantPtr = struct;
+    return cast vptr.getUnderlyingPointer();
   }
 
   /**

--- a/Haxe/Static/unreal/Ptr.hx
+++ b/Haxe/Static/unreal/Ptr.hx
@@ -21,8 +21,7 @@ abstract Ptr<T>(PtrMacros<T>) {
   }
 
   public static function fromStruct<T : Struct>(struct : Struct):Ptr<T> {
-    var vptr:VariantPtr = struct;
-    return cast vptr.getUnderlyingPointer();
+    return cast uhx.internal.HaxeHelpers.getUnderlyingPointer(struct);
   }
 
   /**

--- a/Haxe/Static/unreal/PtrMacros.hx
+++ b/Haxe/Static/unreal/PtrMacros.hx
@@ -58,7 +58,7 @@ abstract PtrMacros<T>(PtrBase<T>) {
       case CStruct(_):
         var isPointer = t.modifiers != null && (t.modifiers.has(Ref) || t.modifiers.has(Ptr));
         if (isPointer) {
-          return macro (cast $ethis : unreal.AnyPtr).setPointer(0, uhx.internal.Helpers.getWrapperPointer($val));
+          return macro (cast $ethis : unreal.AnyPtr).setPointer(0, uhx.internal.HaxeHelpers.getUnderlyingPointer($val));
         }
         var type = t.haxeType.toComplexType();
         try {
@@ -136,7 +136,7 @@ abstract PtrMacros<T>(PtrBase<T>) {
         var tpath = conv.haxeType.toTypePath();
         return macro @:mergeBlock {
           var ret = new $tpath();
-          cast uhx.internal.Helpers.getWrapperPointer(ret);
+          cast uhx.internal.HaxeHelpers.getUnderlyingPointer(ret);
         };
       case _:
         throw new Error("PtrMacros: Unsupported type : " + t, pos);

--- a/Haxe/Static/unreal/Ref.hx
+++ b/Haxe/Static/unreal/Ref.hx
@@ -22,8 +22,7 @@ abstract Ref<T>(PtrMacros<T>) {
   }
 
   public static function fromStruct<T : Struct>(struct : Struct):Ref<T> {
-    var vptr:VariantPtr = struct;
-    return cast vptr.getUnderlyingPointer();
+    return cast uhx.internal.HaxeHelpers.getUnderlyingPointer(struct);
   }
 
   /**

--- a/Haxe/Static/unreal/Ref.hx
+++ b/Haxe/Static/unreal/Ref.hx
@@ -8,7 +8,7 @@ package unreal;
 abstract Ref<T>(PtrMacros<T>) {
   /**
     Creates a reference of the target type in the stack. The reference is only guaranteed to be
-    alive 
+    alive
   **/
   macro public static function createStack<T>():haxe.macro.Expr.ExprOf<Ref<T>> {
     return PtrMacros.createStackHelper(false);
@@ -22,7 +22,8 @@ abstract Ref<T>(PtrMacros<T>) {
   }
 
   public static function fromStruct<T : Struct>(struct : Struct):Ref<T> {
-    return cast uhx.internal.Helpers.getWrapperPointer(struct);
+    var vptr:VariantPtr = struct;
+    return cast vptr.getUnderlyingPointer();
   }
 
   /**

--- a/Haxe/Static/unreal/ReflectAPI.hx
+++ b/Haxe/Static/unreal/ReflectAPI.hx
@@ -257,7 +257,7 @@ class ReflectAPI {
           } else {
             var variant : VariantPtr = curArg;
             if (!variant.isObject()) {
-              argAddr = (curArg : VariantPtr).getUIntPtr() - 1;
+              argAddr = variant.getExternalPointerUnchecked();
             } else {
               argAddr = curArg; // plain UIntPtr
             }
@@ -404,7 +404,7 @@ class ReflectAPI {
       } else {
         var variant:VariantPtr = value;
         if (!variant.isObject()) {
-          prop.CopyCompleteValue(objOffset, variant.getUIntPtr() - 1);
+          prop.CopyCompleteValue(objOffset, variant.getExternalPointerUnchecked());
         } else {
           throw 'Struct set not supported: ${prop.GetName()} for value $value' #if debug + ' ($path)' #end;
         }
@@ -414,7 +414,7 @@ class ReflectAPI {
           struct = prop.Struct;
       var variant:VariantPtr = value;
       if (!variant.isObject()) {
-          prop.CopyCompleteValue(objOffset, variant.getUIntPtr() - 1);
+          prop.CopyCompleteValue(objOffset, variant.getExternalPointerUnchecked());
       } else if (Std.is(value, unreal.Wrapper)) {
         var wrapperValue:unreal.Wrapper = value;
         prop.CopyCompleteValue(objOffset, wrapperValue.getPointer());
@@ -553,21 +553,21 @@ class ReflectAPI {
       return prop.GetObjectPropertyValue(objPtr);
     } else if (Std.is(prop, UNameProperty)) {
       if (rawPointers && (propFlags = prop.PropertyFlags).hasAny(CPF_ReferenceParm | CPF_OutParm) && !propFlags.hasAny(CPF_ConstParm)) {
-        return VariantPtr.fromUIntPtrExternalPointer(objPtr);
+        return VariantPtr.fromExternalPointer(objPtr);
       }
       var value:FName = "";
       prop.CopyCompleteValue(AnyPtr.fromStruct(value),objPtr);
       return value;
     } else if (Std.is(prop, UStrProperty)) {
       if (rawPointers && (propFlags = prop.PropertyFlags).hasAny(CPF_ReferenceParm | CPF_OutParm) && !propFlags.hasAny(CPF_ConstParm)) {
-        return VariantPtr.fromUIntPtrExternalPointer(objPtr);
+        return VariantPtr.fromExternalPointer(objPtr);
       }
       var value:FString = "";
       prop.CopyCompleteValue(AnyPtr.fromStruct(value),objPtr);
       return value;
     } else if (Std.is(prop, UTextProperty)) {
       if (rawPointers && (propFlags = prop.PropertyFlags).hasAny(CPF_ReferenceParm | CPF_OutParm) && !propFlags.hasAny(CPF_ConstParm)) {
-        return VariantPtr.fromUIntPtrExternalPointer(objPtr);
+        return VariantPtr.fromExternalPointer(objPtr);
       }
       var value:FText = "";
       prop.CopyCompleteValue(AnyPtr.fromStruct(value),objPtr);

--- a/Haxe/Static/unreal/TArray.hx
+++ b/Haxe/Static/unreal/TArray.hx
@@ -172,12 +172,7 @@ private typedef TArrayImpl<T> = Dynamic;
       }
     } else {
       var vptr:VariantPtr = cast obj,
-          obj:UIntPtr = 0;
-      if (vptr.isObject()) {
-        obj = vptr.getDynamic().getPointer();
-      } else {
-        obj = vptr.getUIntPtr() - 1;
-      }
+          obj:UIntPtr = vptr.getUnderlyingPointer();
 
       var data = this.GetData();
       for(i in 0...len) {

--- a/Haxe/Static/unreal/TemplateStruct.hx
+++ b/Haxe/Static/unreal/TemplateStruct.hx
@@ -8,6 +8,6 @@ abstract TemplateStruct(Struct) to Struct to VariantPtr {
       trace('Fatal', 'Assert failure: `this` is not a TemplateWrapper: $this');
     }
 #end
-    return untyped __cpp__('::hx::ObjectPtr< ::unreal::TemplateWrapper_obj >( (::unreal::TemplateWrapper_obj *) {0}.raw )', this);
+    return untyped __cpp__('::hx::ObjectPtr< ::unreal::TemplateWrapper_obj >( (::unreal::TemplateWrapper_obj *) {0}.getGcPointerUnchecked() )', this);
   }
 }

--- a/Haxe/Static/unreal/VariantPtr.hx
+++ b/Haxe/Static/unreal/VariantPtr.hx
@@ -2,32 +2,18 @@ package unreal;
 
 @:include("VariantPtr.h") @:native("unreal.VariantPtr")
 extern class VariantPtr {
-  var raw(default, null):UIntPtr;
   /**
     Creates a `VariantPtr` from a Haxe object
    **/
   public static function fromDynamic(obj:Dynamic):VariantPtr;
 
   /**
-    Creates a `VariantPtr` from an `IntPtr`.
+    Creates a `VariantPtr` from an external `UIntPtr`
    **/
-  public static function fromIntPtr(intPtr:IntPtr):VariantPtr;
+  public static function fromExternalPointer(uintPtr:UIntPtr):VariantPtr;
 
-  /**
-    Creates a `VariantPtr` from an `IntPtr`. This directly sets `uintPtr` value as the raw value of VariantPtr.
-    If you want to set an external pointer with this, use `fromUIntPtrExternalPointer` instead
-   **/
-  public static function fromUIntPtr(uintPtr:UIntPtr):VariantPtr;
-
-  /**
-    Creates a `VariantPtr` from an `IntPtr`, considering it an external pointer (like `fromPointer` / `fromRawPtr` )
-    This differs from `fromUIntPtr` as it will set the bit as if the pointer references external code
-  **/
-  public static function fromUIntPtrExternalPointer(uintPtr:UIntPtr):VariantPtr;
 #if cpp
-  public static function fromPointer<T>(ptr:cpp.Pointer<T>):VariantPtr;
-
-  public static function fromRawPtr<T>(ptr:cpp.RawPointer<T>):VariantPtr;
+  public static function fromExternalHxcppPointer<T>(ptr:cpp.Pointer<T>):VariantPtr;
 #end
 
   /**
@@ -36,21 +22,24 @@ extern class VariantPtr {
   public function getDynamic():Null<Dynamic>;
 
   /**
-    Gets its underlying IntPtr value
-   **/
-  public function getIntPtr():IntPtr;
-
-  /**
-    Gets its underlying UIntPtr value
-   **/
-  public function getUIntPtr():UIntPtr;
-
-  /**
     Returns whether `this` represents an object or an `IntPtr` value
    **/
   public function isObject():Bool;
 
-#if cpp
-  public function toPointer():cpp.RawPointer<cpp.Void>;
-#end
+  public function isExternalPointer():Bool;
+
+  public function getExternalPointerUnchecked():UIntPtr;
+
+  public function getGcPointerUnchecked():UIntPtr;
+
+  public function getExternalPointer():UIntPtr;
+
+  /**
+   * If it's an external pointer, returns the pointer itself
+   * Otherwise, the Dynamic object is assyned to be an unreal.Wrapper type,
+   * and `getPointer()` is called, so the underlying native pointer is returned
+   **/
+  public function getUnderlyingPointer():UIntPtr;
+
+  public function getUIntPtrRepresentation():UIntPtr;
 }

--- a/Haxe/Static/unreal/automation/AutomationTest.hx
+++ b/Haxe/Static/unreal/automation/AutomationTest.hx
@@ -21,7 +21,7 @@ public:
       uhx::internal::AutomationExpose::isComplexTask(inHaxeRef))
   {
     haxeGcRef.set(inHaxeRef);
-    uhx::internal::AutomationExpose::setWrapped(inHaxeRef, unreal::VariantPtr(this));
+    uhx::internal::AutomationExpose::setWrapped(inHaxeRef, unreal::VariantPtr::fromExternalPointer(this));
   }
 
   virtual uint32 GetTestFlags() const override {
@@ -45,7 +45,7 @@ public:
   }
 
   virtual bool RunTest(const FString& params) override {
-    return uhx::internal::AutomationExpose::runTest(haxeGcRef.get(), unreal::VariantPtr(&params));
+    return uhx::internal::AutomationExpose::runTest(haxeGcRef.get(), unreal::VariantPtr::fromExternalPointer(&params));
   }
 
   virtual FString GetBeautifiedTestName() const override {

--- a/Haxe/Static/unreal/automation/LatentCommand.hx
+++ b/Haxe/Static/unreal/automation/LatentCommand.hx
@@ -24,7 +24,7 @@ public:
 };
 
 unreal::VariantPtr uhx::internal::HaxeLatentCommand_Glue_obj::createFn(unreal::UIntPtr fn) {
-  return unreal::VariantPtr( new FHaxeLatentCommand(fn) );
+  return unreal::VariantPtr::fromExternalPointer( new FHaxeLatentCommand(fn) );
 }')
   public static function createFn(fn:Void->Bool):POwnedPtr<IAutomationLatentCommand> {
     return cast uhx.internal.HaxeLatentCommand_Glue.createFn(uhx.internal.HaxeHelpers.dynamicToPointer(fn));

--- a/Haxe/Templates/Source/HaxeRuntime/Export/CallHelper.h
+++ b/Haxe/Templates/Source/HaxeRuntime/Export/CallHelper.h
@@ -11,7 +11,7 @@ class HAXERUNTIME_API UCallHelper : public UObject {
 public:
   GENERATED_BODY()
   static void uhx_callFunctionOther(UObject* Context, FFrame& Stack, RESULT_DECL ) {
-    ::uhx::expose::HxcppRuntime::callHaxeFunctionOther(unreal::VariantPtr(&Stack), (unreal::UIntPtr) RESULT_PARAM);
+    ::uhx::expose::HxcppRuntime::callHaxeFunctionOther(unreal::VariantPtr::fromExternalPointer(&Stack), (unreal::UIntPtr) RESULT_PARAM);
   }
 
   static void setupFunction(void *cls, void *fn) {

--- a/Haxe/Templates/Source/HaxeRuntime/Private/HaxeGeneratedClass.cpp
+++ b/Haxe/Templates/Source/HaxeRuntime/Private/HaxeGeneratedClass.cpp
@@ -18,7 +18,7 @@ void UHaxeGeneratedClass::GetLifetimeBlueprintReplicationList(TArray<class FLife
 void UHaxeGeneratedClass::InstancePreReplication(UObject* Obj, class IRepChangedPropertyTracker& ChangedPropertyTracker) const {
   uhx::expose::HxcppRuntime::instancePreReplication(
       (unreal::UIntPtr) Obj,
-      unreal::VariantPtr(&ChangedPropertyTracker));
+      unreal::VariantPtr::fromExternalPointer(&ChangedPropertyTracker));
 }
 
 void UHaxeGeneratedClass::cdoInit() {

--- a/Haxe/Templates/Source/HaxeRuntime/Private/VariantPtr.cpp
+++ b/Haxe/Templates/Source/HaxeRuntime/Private/VariantPtr.cpp
@@ -1,9 +1,0 @@
-#include "HaxeRuntime.h"
-#include "VariantPtr.h"
-#include "CoreMinimal.h"
-#include "HaxeInit.h"
-
-void unreal::VariantPtr::badAlignmentAssert(UIntPtr value)
-{
-  UE_LOG(HaxeLog, Fatal, TEXT("The pointer %llx was not aligned and is not supported by Unreal.hx"), value);
-}

--- a/Haxe/Templates/Source/HaxeRuntime/Public/uhx/TypeParamGlue.h
+++ b/Haxe/Templates/Source/HaxeRuntime/Public/uhx/TypeParamGlue.h
@@ -464,21 +464,21 @@ struct TTemplatedData<T<First, Values...>> {
 template<template<typename, typename...> class T, typename First, typename... Values>
 struct TypeParamGlue<T<First, Values...>, OtherType> {
   inline static T<First, Values...> haxeToUe(unreal::UIntPtr haxe) {
-    return *TemplateHelper<T<First, Values...>>::getPointer(unreal::VariantPtr(haxe));
+    return *TemplateHelper<T<First, Values...>>::getPointer(unreal::VariantPtr::fromUIntPtrRepresentation(haxe));
   }
 
   inline static unreal::UIntPtr ueToHaxe(T<First, Values...> ue) {
-    return TemplateHelper<T<First, Values...>>::fromStruct(ue).raw;
+    return TemplateHelper<T<First, Values...>>::fromStruct(ue).getGcPointerUnchecked();
   }
 };
 template<template<typename, typename...> class T, typename First, typename... Values>
 struct TypeParamGluePtr<T<First, Values...>, OtherType> {
   inline static typename PtrMaker<T<First, Values...>>::Type haxeToUePtr(unreal::UIntPtr haxe) {
-    return typename PtrMaker<T<First, Values...>>::Type( TemplateHelper<T<First, Values...>>::getPointer(haxe) );
+    return typename PtrMaker<T<First, Values...>>::Type( TemplateHelper<T<First, Values...>>::getPointer(unreal::VariantPtr::fromUIntPtrRepresentation(haxe)) );
   }
 
   inline static unreal::UIntPtr ueToHaxeRef(T<First, Values...>& ue) {
-    return TemplateHelper<T<First, Values...>>::fromStruct(ue).raw;
+    return TemplateHelper<T<First, Values...>>::fromStruct(ue).getGcPointerUnchecked();
   }
 };
 
@@ -491,21 +491,21 @@ struct TTemplatedData<T<First, Mode>> {
 template<ESPMode Mode, template<typename, ESPMode> class T, typename First>
 struct TypeParamGlue<T<First, Mode>, OtherType> {
   inline static T<First, Mode> haxeToUe(unreal::UIntPtr haxe) {
-    return *TemplateHelper<T<First, Mode>>::getPointer(unreal::VariantPtr(haxe));
+    return *TemplateHelper<T<First, Mode>>::getPointer(unreal::VariantPtr::fromUIntPtrRepresentation(haxe));
   }
 
   inline static unreal::UIntPtr ueToHaxe(T<First, Mode> ue) {
-    return TemplateHelper<T<First, Mode>>::fromStruct(ue).raw;
+    return TemplateHelper<T<First, Mode>>::fromStruct(ue).getGcPointerUnchecked();
   }
 };
 template<ESPMode Mode, template<typename, ESPMode> class T, typename First>
 struct TypeParamGluePtr<T<First, Mode>, OtherType> {
   inline static typename PtrMaker<T<First, Mode>>::Type haxeToUePtr(unreal::UIntPtr haxe) {
-    return typename PtrMaker<T<First, Mode>>::Type( *TemplateHelper<T<First, Mode>>::getPointer(haxe) );
+    return typename PtrMaker<T<First, Mode>>::Type( *TemplateHelper<T<First, Mode>>::getPointer(unreal::VariantPtr::fromUIntPtrRepresentation(haxe)) );
   }
 
   inline static unreal::UIntPtr ueToHaxeRef(T<First, Mode>& ue) {
-    return TemplateHelper<T<First, Mode>>::fromStruct(ue).raw;
+    return TemplateHelper<T<First, Mode>>::fromStruct(ue).getGcPointerUnchecked();
   }
 };
 
@@ -513,17 +513,17 @@ struct TypeParamGluePtr<T<First, Mode>, OtherType> {
 template<typename T>
 struct TypeParamGlue<T, OtherType> {
   inline static T haxeToUe(unreal::UIntPtr haxe) {
-    return *StructHelper<T>::getPointer(unreal::VariantPtr(haxe));
+    return *StructHelper<T>::getPointer(unreal::VariantPtr::fromUIntPtrRepresentation(haxe));
   }
 
   inline static unreal::UIntPtr ueToHaxe(T ue) {
-    return StructHelper<T>::fromStruct(ue).raw;
+    return StructHelper<T>::fromStruct(ue).getGcPointerUnchecked();
   }
 };
 template<typename T>
 struct TypeParamGluePtr<T, OtherType> {
   inline static typename PtrMaker<T>::Type haxeToUePtr(unreal::UIntPtr haxe) {
-    return typename PtrMaker<T>::Type( StructHelper<T>::getPointer(haxe) );
+    return typename PtrMaker<T>::Type( StructHelper<T>::getPointer(unreal::VariantPtr::fromUIntPtrRepresentation(haxe)) );
   }
 
   inline static unreal::UIntPtr ueToHaxeRef(T& ue) {
@@ -534,11 +534,11 @@ struct TypeParamGluePtr<T, OtherType> {
 template<typename T>
 struct TypeParamGlue<T*, OtherType> {
   inline static T* haxeToUe(unreal::UIntPtr haxe) {
-    return StructHelper<T>::getPointer(unreal::VariantPtr(haxe));
+    return StructHelper<T>::getPointer(unreal::VariantPtr::fromUIntPtrRepresentation(haxe));
   }
 
   inline static unreal::UIntPtr ueToHaxe(T* ue) {
-    return uhx::expose::HxcppRuntime::boxVariantPtr(unreal::VariantPtr(ue));
+    return uhx::expose::HxcppRuntime::boxVariantPtr(unreal::VariantPtr::fromExternalPointer((unreal::UIntPtr) ue));
   }
 };
 

--- a/Haxe/Templates/Source/HaxeRuntime/Shared/VariantPtr.h
+++ b/Haxe/Templates/Source/HaxeRuntime/Shared/VariantPtr.h
@@ -207,7 +207,7 @@ public:
     {
       return VariantPtr(handle, true);
     } else {
-      return VariantPtr(handle, false);
+      return VariantPtr(inPtr, false);
     }
     #else
     VariantPtr ptr;

--- a/Haxe/Templates/Source/HaxeRuntime/Shared/VariantPtr.h
+++ b/Haxe/Templates/Source/HaxeRuntime/Shared/VariantPtr.h
@@ -1,12 +1,14 @@
 #pragma once
 
 #include "IntPtr.h"
+#include "uhx/Defines.h"
+#include "uhx/expose/BaseRuntime.h"
 
 #ifndef __UNREAL__
 #ifndef HXCPP_H
 #include <hxcpp.h>
 #endif
-#include <cpp/Pointer.h>
+#include "cpp/Pointer.h"
 // #include <hx/LessThanEq.h>
 #endif
 
@@ -20,31 +22,40 @@
 namespace unreal {
 
 class VariantPtr {
-public:
+private:
   UIntPtr raw;
+public:
+  #if UHX_FAT_VARIANTPTR
+  bool isExternal;
 
+  inline VariantPtr() : raw(0), isExternal(false) { }
+private:
+  inline VariantPtr(UIntPtr inPtr, bool isExternal) : raw(inPtr), isExternal(isExternal) {}
+public:
+  #else
   inline VariantPtr() : raw(0) { }
-  inline VariantPtr(const void *inRHS) : raw( inRHS == 0 ? 0 : (((UIntPtr) inRHS) + 1) ) {
-    #if !defined(UE_BUILD_SHIPPING) || !UE_BUILD_SHIPPING
-    if(raw != 0 && (raw & 1) != 1) { this->badAlignmentAssert(raw -1); }
-    #endif
-  }
-  inline VariantPtr(void *inRHS) : raw( inRHS == 0 ? 0 : (((UIntPtr) inRHS) + 1) ) {
-    #if !defined(UE_BUILD_SHIPPING) || !UE_BUILD_SHIPPING
-    if(raw != 0 && (raw & 1) != 1) { this->badAlignmentAssert(raw -1); }
-    #endif
-  }
-  inline VariantPtr(IntPtr inRHS) : raw((UIntPtr) inRHS) { }
-  inline VariantPtr(UIntPtr inRHS) : raw(inRHS) { }
-  inline VariantPtr(int inRHS) : raw((UIntPtr) inRHS) { }
+private:
+  inline VariantPtr(UIntPtr inPtr, bool isExternal) : raw(inPtr) {}
+public:
+  #endif
+
 #ifndef __UNREAL__
   inline VariantPtr(const Dynamic& inRHS) {
+    #if UHX_FAT_VARIANTPTR
+    this->isExternal = false;
+    #endif
+
     if (inRHS.mPtr == 0) {
       this->raw = 0;
     } else {
       void *hnd = inRHS->__GetHandle();
       if (hnd != 0) {
-        this->raw = ((UIntPtr) hnd) + 1;
+        #if UHX_FAT_VARIANTPTR
+        this->isExternal = true;
+        this->raw = ((UIntPtr) hnd);
+        #else
+        this->raw = ~((UIntPtr)hnd);
+        #endif
       } else {
         this->raw = (UIntPtr) inRHS.mPtr;
       }
@@ -53,26 +64,35 @@ public:
 
   inline VariantPtr(const cpp::Variant& inVariant) {
     Dynamic inRHS = Dynamic(inVariant);
+    #if UHX_FAT_VARIANTPTR
+    this->isExternal = false;
+    #endif
+
     if (inRHS.mPtr == 0) {
       this->raw = 0;
     } else {
       void *hnd = inRHS->__GetHandle();
       if (hnd != 0) {
-        this->raw = ((UIntPtr) hnd) + 1;
+        #if UHX_FAT_VARIANTPTR
+        this->isExternal = true;
+        this->raw = ((UIntPtr) hnd);
+        #else
+        this->raw = ~((UIntPtr)hnd);
+        #endif
       } else {
         this->raw = (UIntPtr) inRHS.mPtr;
       }
     }
   }
 
+  #if UHX_FAT_VARIANTPTR
+  inline VariantPtr(const null& inRHS) : raw(0), isExternal(false) { }
+  #else
   inline VariantPtr(const null& inRHS) : raw(0) { }
+  #endif
 
   inline operator Dynamic() const {
     return this->getDynamic();
-  }
-
-  inline bool operator ==(const VariantPtr &other) const {
-    return this->raw == other.raw;
   }
 
   inline bool operator ==(const null &other) const {
@@ -80,55 +100,182 @@ public:
   }
 
   inline Dynamic getDynamic() const {
-    if ((raw & 1) == 0) {
-      return Dynamic((hx::Object *)raw);
+    if (this->raw == 0)
+    {
+      return Dynamic((hx::Object *) nullptr);
+    }
+
+    UIntPtr ptr = this->getExternalPointer();
+    if (ptr == 0)
+    {
+      return Dynamic((hx::Object *) raw);
     } else {
-      return cpp::Pointer<void>((void *) (raw - 1));
+      return cpp::Pointer<void>((void *) (ptr));
     }
   }
 #else
+  #if UHX_FAT_VARIANTPTR
+  inline VariantPtr(const std::nullptr_t& inRHS) : raw(0), isExternal(false) { }
+  #else
   inline VariantPtr(const std::nullptr_t& inRHS) : raw(0) { }
+  #endif
+
+
+  inline bool operator ==(const std::nullptr_t &other) const {
+    return this->raw == 0;
+  }
 #endif
+
+  inline bool operator ==(const VariantPtr &other) const {
+    return this->raw == other.raw;
+  }
 
   // Allow '->' syntax
   inline VariantPtr *operator->() { return this; }
 
-  inline IntPtr getIntPtr() const { return (IntPtr) raw; }
-  inline UIntPtr getUIntPtr() const { return (UIntPtr) raw; }
-
-  inline bool isObject() const { return (raw & 1) == 0; }
-
-  // inline operator UIntPtr() { return raw; }
-
-  void badAlignmentAssert(UIntPtr value);
-
-  inline void *toPointer() const {
-    return ((raw & 1) == 1) ? ( (void *) (raw - 1) ) : haxeObjToPointer(raw);
+  inline bool isObject() const {
+    return !this->isExternalPointer();
   }
 
-  static void *haxeObjToPointer(UIntPtr inRaw) {
-    return 0;
+  inline bool isExternalPointer() const {
+    #if UHX_FAT_VARIANTPTR
+    return this->isExternal;
+    #else
+    return (this->raw & (1LL << 63)) != 0;
+    #endif
+  }
+
+  inline UIntPtr getExternalPointerUnchecked() const {
+    #if UHX_FAT_VARIANTPTR
+    return this->raw;
+    #else
+    return (this->raw == 0) ? 0 : ~this->raw;
+    #endif
+  }
+
+  inline UIntPtr getGcPointerUnchecked() const {
+    return this->raw;
+  }
+
+  inline bool isNull() const {
+    return this->raw == 0;
+  }
+
+  /**
+   * If it's an external pointer, returns the pointer itself
+   * Otherwise, the Dynamic object is assyned to be an unreal.Wrapper type,
+   * and `getPointer()` is called, so the underlying native pointer is returned
+   **/
+  inline UIntPtr getUnderlyingPointer() const {
+    if (this->raw == 0)
+    {
+      return 0;
+    }
+
+    if (this->isExternalPointer())
+    {
+      return this->getExternalPointerUnchecked();
+    } else {
+      return uhx::expose::BaseRuntime::wrapperObjectToPointer(this->raw);
+    }
+  }
+
+  /**
+   * Returns the most efficient representation possible of `this` VariantPtr
+   * to a UIntPtr. This may mean that in some platforms the result will need to be boxed
+   **/
+  inline UIntPtr getUIntPtrRepresentation() const {
+    #if UHX_FAT_VARIANTPTR
+    // By definition, we cannot get a full representation of a VariantPtr into an UIntPtr
+    // when using fat variantptrs. So instead we're going to box it
+    if (this->isExternalPointer())
+    {
+      return uhx::expose::BaseRuntime::boxPointer(this->raw);
+    } else {
+      return this->raw;
+    }
+    #else
+    return this->raw;
+    #endif
+  }
+
+  inline static VariantPtr fromUIntPtrRepresentation(UIntPtr inPtr)
+  {
+    #if UHX_FAT_VARIANTPTR
+    UIntPtr handle = uhx::expose::BaseRuntime::getPointerHandle(inPtr);
+    if (handle != 0)
+    {
+      return VariantPtr(handle, true);
+    } else {
+      return VariantPtr(handle, false);
+    }
+    #else
+    VariantPtr ptr;
+    ptr.raw = inPtr;
+    return ptr;
+    #endif
+  }
+
+  static void badPointerAssert(UIntPtr inPtr)
+  {
+    // if this happened, it means it's probably not safe to use the
+    // most significant bit as an indicator of external pointers on this platform
+    // If that's the case, make sure to define UHX_FAT_VARIANTPTR  for this platform
+    // (see uhx/Defines.h)
+    uhx::expose::BaseRuntime::throwBadPointer(inPtr);
+  }
+
+  inline UIntPtr getExternalPointer() const {
+    #if UHX_FAT_VARIANTPTR
+    return (this->isExternal) ? (this->raw) : 0;
+    #else
+    return ((this->raw & (1LL << 63)) != 0) ? ~this->raw : 0;
+    #endif
+  }
+
+  inline static VariantPtr fromExternalPointer(const void *inPtr)
+  {
+    return fromExternalPointer((UIntPtr) inPtr);
+  }
+
+  inline static VariantPtr fromExternalPointer(UIntPtr inPtr)
+  {
+    if (inPtr == 0)
+    {
+      return VariantPtr(0, false);
+    }
+    #if UHX_FAT_VARIANTPTR
+    return VariantPtr(inPtr, true);
+    #else
+    #if UHX_DEBUG
+    if ((inPtr & (1LL << 63)) != 0)
+    {
+      badPointerAssert(inPtr);
+    }
+    #endif
+    return VariantPtr(~inPtr, true);
+    #endif
+  }
+
+  inline static VariantPtr fromGcPointer(UIntPtr inPtr)
+  {
+    return VariantPtr(inPtr, false);
   }
 };
 
 class VariantPtr_obj {
 public:
-  inline static VariantPtr fromIntPtr(IntPtr inPtr) { return VariantPtr(inPtr); }
-  inline static VariantPtr fromUIntPtr(UIntPtr inPtr) { return VariantPtr(inPtr); }
-  inline static VariantPtr fromRawPtr(void *inPtr) { return VariantPtr( (void *) inPtr ); }
-  inline static VariantPtr fromRawPtr(const void *inPtr) { return VariantPtr( (void *) inPtr ); }
+  inline static VariantPtr fromExternalPointer(UIntPtr inPtr) { return VariantPtr::fromExternalPointer(inPtr); }
   template<typename T>
-  inline static VariantPtr fromRawPtr(T *inPtr) { return VariantPtr( (void *) inPtr ); }
+  inline static VariantPtr fromExternalRawPtr(T *inPtr) { return VariantPtr::fromExternalPointer( (UIntPtr) inPtr ); }
   template<typename T>
-  inline static VariantPtr fromRawPtr(const T *inPtr) { return VariantPtr( (void *) inPtr ); }
+  inline static VariantPtr fromExternalRawPtr(const T *inPtr) { return VariantPtr::fromExternalPointer( (UIntPtr) inPtr ); }
 #ifndef __UNREAL__
   template<typename T>
-  inline static VariantPtr fromPointer(cpp::Pointer<T> inPtr) { return VariantPtr( (void *) inPtr ); }
+  inline static VariantPtr fromExternalHxcppPointer(cpp::Pointer<T> inPtr) { return VariantPtr::fromExternalPointer( (UIntPtr) inPtr ); }
 
   inline static VariantPtr fromDynamic(Dynamic inDyn) { return VariantPtr( inDyn ); }
 #endif
-
-  inline static VariantPtr fromUIntPtrExternalPointer(UIntPtr inPtr) { return VariantPtr((void*) inPtr); }
 };
 
 }
@@ -137,8 +284,8 @@ public:
 namespace hx {
 template<> inline void MarkMember< unreal::VariantPtr >(unreal::VariantPtr &outT,hx::MarkContext *__inCtx)
 {
-  if ((outT.raw & 1) == 0) {
-    HX_MARK_OBJECT((hx::Object *) outT.raw);
+  if (outT.isObject()) {
+    HX_MARK_OBJECT((hx::Object *) outT.getGcPointerUnchecked());
   }
 }
 
@@ -147,14 +294,14 @@ struct CompareTraits<unreal::VariantPtr>
 {
    enum { type = (int)CompareAsInt64 };
 
-   inline static int toInt(unreal::VariantPtr inValue) { return (int) inValue.raw; }
-   inline static double toDouble(unreal::VariantPtr inValue) { return (double) inValue.raw; }
-   inline static cpp::Int64 toInt64(unreal::VariantPtr inValue) { return (cpp::Int64) inValue.raw; }
+   inline static int toInt(unreal::VariantPtr inValue) { return (int) inValue.getGcPointerUnchecked(); }
+   inline static double toDouble(unreal::VariantPtr inValue) { return (double) inValue.getGcPointerUnchecked(); }
+   inline static cpp::Int64 toInt64(unreal::VariantPtr inValue) { return (cpp::Int64) inValue.getGcPointerUnchecked(); }
    inline static String toString(unreal::VariantPtr inValue) { return inValue.getDynamic(); }
    inline static hx::Object *toObject(unreal::VariantPtr inValue) { return inValue.getDynamic().mPtr; }
 
    inline static int getDynamicCompareType(unreal::VariantPtr) { return type; }
-   inline static bool isNull(const unreal::VariantPtr &inValue) { return inValue.raw == 0; }
+   inline static bool isNull(const unreal::VariantPtr &inValue) { return inValue.isNull(); }
 };
 
 template<>

--- a/Haxe/Templates/Source/HaxeRuntime/Shared/uhx/Defines.h
+++ b/Haxe/Templates/Source/HaxeRuntime/Shared/uhx/Defines.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#ifndef UHX_FAT_VARIANTPTR
+// For now we default to use fat pointers if we're not on a 64-bit platform
+// However the trick for 64-bit platforms is not universal and depends on the fact
+// that in both Linux and Windows, negative pointers are reserved for kernel memory
+// so we can be sure that these addresses are unused
+  #if defined(_WIN32) || defined(_WIN64)
+    #if defined(_WIN64) && _WIN64
+      #define UHX_FAT_VARIANTPTR 0
+    #else
+      #define UHX_FAT_VARIANTPTR 1
+    #endif
+  #elif defined(__x86_64__) && __x86_64__
+      #define UHX_FAT_VARIANTPTR 0
+  #else
+    #define UHX_FAT_VARIANTPTR 1
+  #endif
+
+#endif
+
+#ifndef UHX_DEBUG
+#if defined(UE_BUILD_SHIPPING)
+#define UHX_DEBUG !UE_BUILD_SHIPPING
+#elif defined(HXCPP_DEBUG)
+#define UHX_DEBUG HXCPP_DEBUG
+#else
+#define UHX_DEBUG 0
+#endif
+#endif


### PR DESCRIPTION
Also, allow the implementation to be swapped, and add
a fat pointer implementation for platforms where the most
significant bit cannot be safely used as a tag (e.g. 32-bit platforms)